### PR TITLE
feat: add variable to disabled deletion protection

### DIFF
--- a/modules/escale-rds/main.tf
+++ b/modules/escale-rds/main.tf
@@ -14,7 +14,7 @@ resource "aws_db_instance" "db" {
   db_subnet_group_name            = var.subnet_group
   final_snapshot_identifier       = "Ignore"
   tags                            = var.rds_tags
-  deletion_protection             = true
+  deletion_protection             = var.deletion_protection
   auto_minor_version_upgrade      = true
   apply_immediately               = true
   maintenance_window              = var.maintenance_window

--- a/modules/escale-rds/variables.tf
+++ b/modules/escale-rds/variables.tf
@@ -140,3 +140,9 @@ variable "enabled_cloudwatch_logs_exports" {
   type        = set(string)
   default     = null
 }
+
+variable "deletion_protection" {
+  description = "Set of the DB instance should have deletion protection enabled"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
We need delete rds instance, but we can't because deletion_protection