### PR TITLE
refactor: avoid rebuild when using affinity

### DIFF
--- a/modules/app-deploy/deployment.tf
+++ b/modules/app-deploy/deployment.tf
@@ -250,6 +250,7 @@ resource "kubernetes_deployment" "main" {
   lifecycle {
     ignore_changes = [
       spec.0.template.0.spec.0.container.0.image,
+      spec.0.template.0.spec.0.affinity,
       spec.0.template.0.metadata.0.annotations["keel.sh/update-time"],
       metadata.resource_version
     ]


### PR DESCRIPTION
Just a workaround as deployment is asked to rebuild on every terraform
plan.

It means we'll need to do manual changes in case we need to change
anything on affinity rules. Ugly but it's the way we can make it work.