### PR TITLE
fix: load balancer listener needs a default certificate

### DIFF
--- a/modules/s3-website-vpc-endpoint/data.tf
+++ b/modules/s3-website-vpc-endpoint/data.tf
@@ -7,8 +7,14 @@ data "aws_vpc" "vpc" {
   }
 }
 
-data "aws_acm_certificate" "domains" {
-  for_each    = toset(var.domains)
+data "aws_acm_certificate" "default_domain" {
+  domain      = var.default_domain
+  types       = ["AMAZON_ISSUED"]
+  most_recent = true
+}
+
+data "aws_acm_certificate" "additional_domains" {
+  for_each    = toset(var.additional_domains)
   domain      = each.value
   types       = ["AMAZON_ISSUED"]
   most_recent = true

--- a/modules/s3-website-vpc-endpoint/lb.tf
+++ b/modules/s3-website-vpc-endpoint/lb.tf
@@ -33,10 +33,12 @@ resource "aws_lb_listener" "internal_https" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.internal.arn
   }
+
+  certificate_arn = data.aws_acm_certificate.default_domain.arn
 }
 
 resource "aws_lb_listener_certificate" "internal" {
-  for_each        = data.aws_acm_certificate.domains
+  for_each        = data.aws_acm_certificate.additional_domains
   listener_arn    = aws_lb_listener.internal_https.arn
   certificate_arn = each.value.arn
 }

--- a/modules/s3-website-vpc-endpoint/variables.tf
+++ b/modules/s3-website-vpc-endpoint/variables.tf
@@ -1,8 +1,8 @@
 variable "subnets" { type = list(any) }
 variable "tags" { type = map(any) }
 variable "vpc_name" { type = string }
+variable "default_domain" { type = string }
 
-
-variable "domains" {
+variable "additional_domains" {
   type = list(string)
 }


### PR DESCRIPTION
aws_lb_listener needs certificate_arn when protocol is HTTPS
This commit splits var.domains in var.default_domain &
var.additional_domains