### PR TITLE
chore: filters only lead-data-platform logs in Datadog

### DIFF
--- a/modules/k8s-deploy/kube-system/datadog.tf
+++ b/modules/k8s-deploy/kube-system/datadog.tf
@@ -67,8 +67,8 @@ resource "helm_release" "datadog_agent" {
   }
 
   set {
-    name  = "datadog.containerExcludeLogs"
-    value = "kube_namespace:kube-system kube_namespace:ingress-nginx kube_namespace:cert-manager kube_namespace:lens-metrics kube_namespace:oauth2-proxy"
+    name  = "datadog.containerIncludeLogs"
+    value = "kube_namespace:lead-data-platform"
   }
 
   values = [


### PR DESCRIPTION
## Why is this Pull Request necessary?
We need to collect only the Lead Platform logs with the Datadog agent.

## How does it fix the issue?
By adjusting the agent filter to include only the `lead-data-platform` namespace.

## Reference
The `datadog.containerIncludeLogs` parameter described in the [Datadog Helm readme file](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/README.md).