### PR TITLE
feat: Add zelas-saude namespace to adtadog

### DIFF
--- a/modules/k8s-deploy/kube-system/datadog.tf
+++ b/modules/k8s-deploy/kube-system/datadog.tf
@@ -73,7 +73,7 @@ resource "helm_release" "datadog_agent" {
 
   set {
     name  = "datadog.containerIncludeLogs"
-    value = "kube_namespace:lead-data-platform kube_namespace:lead-platform kube_namespace:finance-bv"
+    value = "kube_namespace:lead-data-platform kube_namespace:lead-platform kube_namespace:finance-bv kube_namespace:zelas-saude"
   }
 
   values = [


### PR DESCRIPTION
HACC-236

Esse PR adiciona o namespace de zelas-saude ao datadog. Foi feito um PR de melhoria dos logs para evitar sujeira no datadog que pode ser visto aqui: https://github.com/escaletech/mtst-zelas-saude/pull/381