### PR TITLE
feat(appconfig): add optional deployment_strategy_id to reuse existin…

### DIFF
--- a/modules/appconfig/main.tf
+++ b/modules/appconfig/main.tf
@@ -19,6 +19,8 @@ resource "aws_appconfig_configuration_profile" "profile" {
 }
 
 resource "aws_appconfig_deployment_strategy" "strategy" {
+  count = var.deployment_strategy_id == null ? 1 : 0
+
   name                           = "${var.app_name}-${var.deployment_strategy_name}"
   description                    = var.deployment_strategy_description
   deployment_duration_in_minutes = var.deployment_duration_in_minutes

--- a/modules/appconfig/outputs.tf
+++ b/modules/appconfig/outputs.tf
@@ -30,5 +30,5 @@ output "configuration_version" {
 
 output "deployment_strategy_id" {
   description = "The ID of the deployment strategy."
-  value       = aws_appconfig_deployment_strategy.strategy.id
+  value       = var.deployment_strategy_id != null ? var.deployment_strategy_id : aws_appconfig_deployment_strategy.strategy[0].id
 }

--- a/modules/appconfig/variables.tf
+++ b/modules/appconfig/variables.tf
@@ -26,6 +26,12 @@ variable "profile_name" {
   default     = "env"
 }
 
+variable "deployment_strategy_id" {
+  description = "The ID of an existing deployment strategy. If provided, skips creating a new one."
+  type        = string
+  default     = null
+}
+
 variable "deployment_strategy_name" {
   description = "The name for the deployment strategy."
   type        = string


### PR DESCRIPTION
…g strategies

When deployment_strategy_id is provided, skips creating a new strategy and uses the existing one. Fully backward compatible - default behavior unchanged.