### PR TITLE
feat(api-gateway): enable gzip compression with default minimum size …

### DIFF
--- a/docs/api-gateway-gzip-compression.md
+++ b/docs/api-gateway-gzip-compression.md
@@ -1,0 +1,97 @@
+# Compressão gzip no API Gateway
+
+Documentação das alterações para habilitar compressão de respostas via `minimum_compression_size` nos módulos de API Gateway REST.
+
+## Contexto
+
+Análise identificou que nenhum módulo de API Gateway neste repositório configurava compressão gzip. Alertas ZaNSHIN apontavam:
+
+> *Configure o API Gateway para utilizar Content Encoding e comprimir a resposta das requisições*
+
+## Solução
+
+Adicionada a variável `minimum_compression_size` nos módulos que criam o REST API:
+
+- [`modules/api-gateway/`](../modules/api-gateway/)
+- [`modules/api-gateway-private/`](../modules/api-gateway-private/)
+
+### Comportamento
+
+| Valor | Efeito |
+|-------|--------|
+| `1024` (default) | Comprime respostas elegíveis >= 1 KB |
+| `-1` | Comprime todas as respostas elegíveis |
+| `null` | Desabilita compressão (opt-out) |
+
+A compressão ocorre quando:
+
+1. A resposta atinge o tamanho mínimo configurado
+2. O cliente envia `Accept-Encoding: gzip`
+3. O `Content-Type` é elegível (`application/json`, `text/html`, `text/plain`, etc.)
+
+O API Gateway adiciona automaticamente o header `Content-Encoding: gzip` — não é necessário configurar encoding nas integrações.
+
+## Módulos alterados
+
+| Módulo | Arquivo | Alteração |
+|--------|---------|-----------|
+| `api-gateway` | `variables.tf` | Nova variável `minimum_compression_size` (default `1024`) |
+| `api-gateway` | `gateway.tf` | `minimum_compression_size` no `aws_api_gateway_rest_api` |
+| `api-gateway-private` | `variables.tf` | Nova variável `minimum_compression_size` (default `1024`) |
+| `api-gateway-private` | `gateway.tf` | `minimum_compression_size` no `aws_api_gateway_rest_api` |
+
+## Módulos fora de escopo
+
+| Módulo | Motivo |
+|--------|--------|
+| `api-gateway-stage` | Compressão é atributo do REST API, não do stage |
+| `api-gateway-method-integration-*` | Integrações não controlam gzip no REST API v1 |
+| `stack-saas` | Referencia API existente via data source; beneficia via `api-gateway-private` |
+
+## Rollout
+
+Após atualizar a referência do módulo:
+
+1. Executar `terraform apply` (REST API recebe `minimum_compression_size = 1024`)
+2. **Criar novo deployment** e atualizar o stage — obrigatório para gzip entrar em vigor
+3. Validar com curl:
+
+```bash
+# Resposta >= 1 KB: deve retornar Content-Encoding: gzip
+curl -H "Accept-Encoding: gzip" -I https://api.exemplo.com/rota-grande
+
+# Resposta < 1 KB: não deve comprimir
+curl -H "Accept-Encoding: gzip" -I https://api.exemplo.com/health
+```
+
+### Opt-out
+
+Stacks que precisarem desabilitar a compressão:
+
+```hcl
+module "api_gateway" {
+  source = "...//modules/api-gateway-private"
+  # ...
+  minimum_compression_size = null
+}
+```
+
+### Compressão total
+
+```hcl
+minimum_compression_size = -1
+```
+
+## Impacto em consumidores
+
+| Cenário | Impacto |
+|---------|---------|
+| Browsers, fetch, axios, mobile | Nenhum — descompressão transparente |
+| Respostas < 1 KB | Nenhum — abaixo do threshold |
+| Clientes sem `Accept-Encoding: gzip` | Nenhum |
+| Content-types binários | Nenhum — não elegíveis |
+| Cliente customizado que não descomprime gzip | Alto — raro; usar `null` para opt-out |
+
+## Atendimento ZaNSHIN
+
+A configuração de `minimum_compression_size > 0` atende o requisito de compressão habilitada no REST API. Para os alertas sumirem, cada API precisa de apply + redeploy. O scanner reavalia após a configuração estar ativa.

--- a/modules/api-gateway-private/README.md
+++ b/modules/api-gateway-private/README.md
@@ -76,6 +76,27 @@ module "api_gateway_private" {
 }
 ```
 
+
+## Compressao de respostas (gzip)
+
+Por padrao, o modulo habilita compressao gzip com `minimum_compression_size = 1024` (respostas >= 1 KB). O API Gateway adiciona automaticamente o header `Content-Encoding: gzip` quando o cliente envia `Accept-Encoding: gzip`.
+
+```hcl
+# Comportamento padrao — nenhum input extra necessario
+module "api_gateway_private" {
+  source = "...//modules/api-gateway-private"
+  # minimum_compression_size = 1024  # default
+}
+
+# Desabilitar compressao
+minimum_compression_size = null
+
+# Comprimir todas as respostas elegiveis
+minimum_compression_size = -1
+```
+
+Apos alterar a configuracao, e necessario criar um **novo deployment** da API para a compressao entrar em vigor.
+
 ## VPC Endpoint
 
 Quando `create_vpc_endpoint = true`, o modulo cria:
@@ -118,6 +139,7 @@ Se `create_proxy_resource = true` e `cors_paths` inclui `/{proxy+}`, o modulo cr
 | `create_proxy_resource` | `bool` | Criar resource `/{proxy+}` quando presente em `cors_paths` | nao | `true` |
 | `cors_paths` | `list(string)` | Paths que devem receber method OPTIONS para CORS | nao | `[]` |
 | `cors_allowed_origins` | `list(string)` | Lista de origens permitidas para CORS | nao | `[]` |
+| `minimum_compression_size` | `number` | Tamanho minimo em bytes para habilitar gzip (`1024` default, `-1` para tudo, `null` para desabilitar) | nao | `1024` |
 
 ## Outputs
 
@@ -128,3 +150,7 @@ Se `create_proxy_resource = true` e `cors_paths` inclui `/{proxy+}`, o modulo cr
 | `gateway_api_arn` | ARN do API Gateway |
 | `vpc_endpoint_ids` | IDs dos VPC Endpoints efetivamente utilizados |
 | `vpc_endpoint_security_group_ids` | IDs dos Security Groups efetivamente utilizados no VPC Endpoint |
+
+## Documentacao
+
+Consulte [`docs/api-gateway-gzip-compression.md`](../../docs/api-gateway-gzip-compression.md) para detalhes sobre rollout, impacto em consumidores e atendimento a alertas ZaNSHIN.

--- a/modules/api-gateway-private/gateway.tf
+++ b/modules/api-gateway-private/gateway.tf
@@ -53,6 +53,7 @@ resource "aws_security_group_rule" "vpc_endpoint_egress_all" {
 resource "aws_api_gateway_rest_api" "gateway_api" {
   name                         = local.name
   disable_execute_api_endpoint = false
+  minimum_compression_size     = var.minimum_compression_size
 
   endpoint_configuration {
     types            = ["PRIVATE"]

--- a/modules/api-gateway-private/variables.tf
+++ b/modules/api-gateway-private/variables.tf
@@ -100,14 +100,25 @@ variable "cors_allowed_origins" {
   default     = []
 }
 
+variable "minimum_compression_size" {
+  description = "Minimum response size in bytes to enable gzip compression on the REST API. Default 1024 compresses responses >= 1 KB. Use -1 to compress all eligible responses. Set null to disable compression."
+  type        = number
+  default     = 1024
+
+  validation {
+    condition     = var.minimum_compression_size == null || (var.minimum_compression_size >= -1 && var.minimum_compression_size <= 10485760)
+    error_message = "minimum_compression_size must be null, -1, or between 0 and 10485760 (10MB)."
+  }
+}
+
 locals {
-  name            = var.name
-  domain          = var.domain
-  certificate_arn = var.certificate_arn
-  vpc_cidr_block  = var.create_vpc_endpoint ? data.aws_vpc.selected[0].cidr_block : null
-  vpc_endpoint_ids_effective = var.create_vpc_endpoint ? [aws_vpc_endpoint.api_gateway_vpc_endpoint[0].id] : var.vpc_endpoint_ids
+  name                                      = var.name
+  domain                                    = var.domain
+  certificate_arn                           = var.certificate_arn
+  vpc_cidr_block                            = var.create_vpc_endpoint ? data.aws_vpc.selected[0].cidr_block : null
+  vpc_endpoint_ids_effective                = var.create_vpc_endpoint ? [aws_vpc_endpoint.api_gateway_vpc_endpoint[0].id] : var.vpc_endpoint_ids
   vpc_endpoint_security_group_ids_effective = var.create_vpc_endpoint ? concat([aws_security_group.vpc_endpoint[0].id], var.vpc_endpoint_security_group_ids) : var.vpc_endpoint_security_group_ids
-  cors_paths_set         = toset(var.cors_paths)
-  cors_proxy_path        = "/{proxy+}"
-  create_proxy_resource_effective = var.create_proxy_resource && contains(local.cors_paths_set, local.cors_proxy_path)
+  cors_paths_set                            = toset(var.cors_paths)
+  cors_proxy_path                           = "/{proxy+}"
+  create_proxy_resource_effective           = var.create_proxy_resource && contains(local.cors_paths_set, local.cors_proxy_path)
 }

--- a/modules/api-gateway/README.md
+++ b/modules/api-gateway/README.md
@@ -1,0 +1,45 @@
+# api-gateway
+
+Modulo Terraform para criar um API Gateway REST publico com custom domain (EDGE), Route53 record e policy de invocacao.
+
+## Compressao de respostas (gzip)
+
+Por padrao, o modulo habilita compressao gzip com `minimum_compression_size = 1024` (respostas >= 1 KB). O API Gateway adiciona automaticamente o header `Content-Encoding: gzip` quando o cliente envia `Accept-Encoding: gzip`.
+
+```hcl
+module "api_gateway" {
+  source = "...//modules/api-gateway"
+
+  name            = "my-api"
+  domain          = "api.example.com"
+  zone            = "example.com"
+  certificate_arn = data.aws_acm_certificate.cert.arn
+
+  # minimum_compression_size = 1024  # default
+}
+```
+
+### Opt-out e override
+
+```hcl
+minimum_compression_size = null  # desabilitar compressao
+minimum_compression_size = -1    # comprimir todas as respostas elegiveis
+```
+
+Apos alterar a configuracao, e necessario criar um **novo deployment** da API para a compressao entrar em vigor.
+
+## Inputs
+
+| Nome | Tipo | Descricao | Obrigatorio | Default |
+|------|------|-----------|-------------|---------|
+| `name` | `string` | Nome do API Gateway | sim | - |
+| `domain` | `string` | Dominio customizado | sim | - |
+| `zone` | `string` | Zona Route53 | sim | - |
+| `certificate_arn` | `string` | ARN do certificado ACM | sim | - |
+| `private_zone` | `bool` | Se a zona Route53 e privada | nao | `false` |
+| `api_key_source` | `string` | Fonte da API Key | nao | `HEADER` |
+| `minimum_compression_size` | `number` | Tamanho minimo em bytes para gzip (`1024` default, `-1` para tudo, `null` para desabilitar) | nao | `1024` |
+
+## Documentacao
+
+Consulte [`docs/api-gateway-gzip-compression.md`](../../docs/api-gateway-gzip-compression.md) para detalhes sobre rollout, impacto em consumidores e atendimento a alertas ZaNSHIN.

--- a/modules/api-gateway/gateway.tf
+++ b/modules/api-gateway/gateway.tf
@@ -7,6 +7,7 @@ resource "aws_api_gateway_rest_api" "gateway_api" {
   name                         = local.name
   disable_execute_api_endpoint = true
   api_key_source               = var.api_key_source
+  minimum_compression_size     = var.minimum_compression_size
 }
 
 resource "aws_api_gateway_rest_api_policy" "policy_invoke" {

--- a/modules/api-gateway/variables.tf
+++ b/modules/api-gateway/variables.tf
@@ -29,6 +29,17 @@ variable "api_key_source" {
   default     = "HEADER"
 }
 
+variable "minimum_compression_size" {
+  description = "Minimum response size in bytes to enable gzip compression on the REST API. Default 1024 compresses responses >= 1 KB. Use -1 to compress all eligible responses. Set null to disable compression."
+  type        = number
+  default     = 1024
+
+  validation {
+    condition     = var.minimum_compression_size == null || (var.minimum_compression_size >= -1 && var.minimum_compression_size <= 10485760)
+    error_message = "minimum_compression_size must be null, -1, or between 0 and 10485760 (10MB)."
+  }
+}
+
 locals {
   domain          = var.domain
   name            = var.name


### PR DESCRIPTION
…1024

Add minimum_compression_size to api-gateway and api-gateway-private modules to address ZaNSHIN alerts for API Gateway response compression.

[Cyber][Zanshin] - O API Gateway não está configurado para comprimir a resposta das requisições