### PR TITLE
feat(ecs): add ecs-task-sftpgo module and parameterize efs access poi…

### DIFF
--- a/modules/ecs-task-sftpgo/README.md
+++ b/modules/ecs-task-sftpgo/README.md
@@ -1,0 +1,5 @@
+# ecs-task-sftpgo
+
+Módulo ECS Fargate para SFTPGo com EFS (host keys), portas SFTP (2022) e admin HTTP (8080), e suporte a policies IAM adicionais (S3).
+
+Baseado em `ecs-task-n8n`, com mount em `/var/lib/sftpgo` e access point `/sftpgo-data`.

--- a/modules/ecs-task-sftpgo/data.tf
+++ b/modules/ecs-task-sftpgo/data.tf
@@ -1,0 +1,7 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy" "ecs_task_cloudwatch_logs_policy" {
+  name = "ecs_task_cloudwatch_logs_policy"
+}

--- a/modules/ecs-task-sftpgo/iam.tf
+++ b/modules/ecs-task-sftpgo/iam.tf
@@ -1,0 +1,38 @@
+resource "aws_iam_role" "ecs_task_role" {
+  name = "ecs-task-role-${var.family}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_ecsTaskExecutionRole" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+  role       = aws_iam_role.ecs_task_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "attach_SecretsManagerReadWrite" {
+  policy_arn = "arn:aws:iam::aws:policy/SecretsManagerReadWrite"
+  role       = aws_iam_role.ecs_task_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "attach_ecs_task_cloudwatch_logs_policy" {
+  policy_arn = data.aws_iam_policy.ecs_task_cloudwatch_logs_policy.arn
+  role       = aws_iam_role.ecs_task_role.name
+}
+
+resource "aws_iam_role_policy_attachment" "attach_additional_policy" {
+  for_each = toset(var.arn_attach_additional_policy)
+
+  policy_arn = each.value
+  role       = aws_iam_role.ecs_task_role.name
+}

--- a/modules/ecs-task-sftpgo/main.tf
+++ b/modules/ecs-task-sftpgo/main.tf
@@ -1,0 +1,125 @@
+locals {
+  provided_port_mappings = var.port_mappings != null ? var.port_mappings : []
+
+  base_port_mappings = (
+    length(local.provided_port_mappings) > 0 ?
+    local.provided_port_mappings :
+    [
+      {
+        container_port = 2022
+        host_port      = 2022
+        protocol       = "tcp"
+        name           = "${var.family}-2022-tcp"
+      },
+      {
+        container_port = 8080
+        host_port      = 8080
+        protocol       = "tcp"
+        app_protocol   = "http"
+        name           = "${var.family}-8080-tcp"
+      }
+    ]
+  )
+
+  normalized_port_mappings = [
+    for mapping in local.base_port_mappings : {
+      for key, value in {
+        containerPort = mapping.container_port
+        hostPort      = lookup(mapping, "host_port", mapping.container_port)
+        protocol      = lookup(mapping, "protocol", "tcp")
+        appProtocol   = lookup(mapping, "app_protocol", null)
+        name          = lookup(mapping, "name", null)
+      } : key => value if value != null
+    }
+  ]
+
+  volume_name = coalesce(var.volume_name, "sftpgo-efs-volume")
+}
+
+module "efs" {
+  source = "github.com/escaletech/terraform-modules/modules/efs"
+
+  service_name                = var.family
+  vpc_id                      = var.vpc_id
+  subnet_ids                  = var.subnet_ids
+  ecs_task_security_group_ids = [var.ecs_task_sg_id]
+  tags                        = var.tags
+
+  performance_mode       = "generalPurpose"
+  throughput_mode        = "bursting"
+  transition_to_ia       = "AFTER_30_DAYS"
+  access_point_root_path = var.access_point_root_path
+  uid                    = var.efs_uid
+  gid                    = var.efs_gid
+  root_permissions       = "0755"
+}
+
+resource "aws_ecs_task_definition" "task_definition" {
+  family                   = var.family
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.ecs_task_role.arn
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+  skip_destroy             = true
+
+  depends_on = [
+    module.efs
+  ]
+
+  volume {
+    name = local.volume_name
+
+    efs_volume_configuration {
+      file_system_id     = module.efs.file_system_id
+      transit_encryption = "ENABLED"
+
+      authorization_config {
+        access_point_id = module.efs.access_point_id
+        iam             = "ENABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([
+    merge(
+      {
+        name      = var.family
+        image     = var.image
+        cpu       = var.cpu
+        memory    = var.memory
+        essential = true
+
+        logConfiguration = {
+          logDriver = "awslogs"
+          options = {
+            awslogs-group         = var.family
+            awslogs-region        = data.aws_region.current.name
+            awslogs-stream-prefix = "task"
+            awslogs-create-group  = "true"
+          }
+        }
+
+        environment = var.environment-variables
+        secrets     = length(var.secrets) > 0 ? var.secrets : []
+
+        mountPoints = [
+          {
+            sourceVolume  = local.volume_name
+            containerPath = var.efs_mount_path
+            readOnly      = false
+          }
+        ]
+      },
+      length(local.normalized_port_mappings) > 0 ? {
+        portMappings = local.normalized_port_mappings
+      } : {}
+    )
+  ])
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = var.cpu_architecture
+  }
+}

--- a/modules/ecs-task-sftpgo/output.tf
+++ b/modules/ecs-task-sftpgo/output.tf
@@ -1,0 +1,9 @@
+output "task_definition_arn" {
+  description = "ARN da definição de tarefa ECS criada."
+  value       = aws_ecs_task_definition.task_definition.arn
+}
+
+output "task_role_arn" {
+  description = "ARN da task role IAM."
+  value       = aws_iam_role.ecs_task_role.arn
+}

--- a/modules/ecs-task-sftpgo/variables.tf
+++ b/modules/ecs-task-sftpgo/variables.tf
@@ -1,0 +1,113 @@
+variable "family" {
+  description = "Nome da tarefa ECS."
+  type        = string
+}
+
+variable "image" {
+  description = "Imagem do container SFTPGo."
+  type        = string
+}
+
+variable "environment-variables" {
+  description = "Variáveis de ambiente da tarefa ECS."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "cpu" {
+  description = "CPU alocada para a tarefa ECS."
+  type        = number
+  default     = 512
+}
+
+variable "memory" {
+  description = "Memória alocada para a tarefa ECS."
+  type        = number
+  default     = 1024
+}
+
+variable "port_mappings" {
+  type = list(object({
+    container_port = number
+    host_port      = optional(number)
+    protocol       = optional(string)
+    app_protocol   = optional(string)
+    name           = optional(string)
+  }))
+  default = null
+}
+
+variable "secrets" {
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  default = []
+}
+
+variable "arn_attach_additional_policy" {
+  description = "Policies IAM adicionais (ex.: S3 scoped)"
+  type        = list(string)
+  default     = []
+}
+
+variable "cpu_architecture" {
+  description = "Arquitetura da CPU para a tarefa ECS."
+  type        = string
+  default     = "X86_64"
+}
+
+variable "vpc_id" {
+  description = "VPC ID onde o EFS será criado."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets onde o EFS criará os mount targets."
+  type        = list(string)
+}
+
+variable "ecs_task_sg_id" {
+  description = "Security Group ID das tasks ECS para acesso ao EFS."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags aplicadas ao EFS."
+  type        = map(string)
+  default     = {}
+}
+
+variable "efs_mount_path" {
+  description = "Caminho de mount do EFS no container (host keys)."
+  type        = string
+  default     = "/var/lib/sftpgo"
+}
+
+variable "access_point_root_path" {
+  description = "Caminho raiz do access point EFS."
+  type        = string
+  default     = "/sftpgo-data"
+}
+
+variable "volume_name" {
+  description = "Nome do volume EFS na task definition."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "efs_uid" {
+  description = "UID do access point EFS."
+  type        = number
+  default     = 1000
+}
+
+variable "efs_gid" {
+  description = "GID do access point EFS."
+  type        = number
+  default     = 1000
+}

--- a/modules/efs/main.tf
+++ b/modules/efs/main.tf
@@ -49,7 +49,7 @@ resource "aws_efs_access_point" "this" {
   }
 
   root_directory {
-    path = "/n8n-data"
+    path = var.access_point_root_path
     creation_info {
       owner_uid   = var.uid
       owner_gid   = var.gid

--- a/modules/efs/variables.tf
+++ b/modules/efs/variables.tf
@@ -60,3 +60,9 @@ variable "efs_mount_path" {
   type        = string
   default     = "/home/node"
 }
+
+variable "access_point_root_path" {
+  description = "Caminho raiz do access point EFS (ex.: /n8n-data, /sftpgo-data)"
+  type        = string
+  default     = "/n8n-data"
+}


### PR DESCRIPTION
…nt path

Introduce a dedicated SFTPGo ECS task module with EFS host-key persistence, multi-port support (2022/8080), and optional IAM policy attachments. Add access_point_root_path to the efs module without breaking existing n8n usage.