### PR TITLE
fix(ecs-task-sftpgo): coerce port mappings and stabilize IAM for_each

### DIFF
--- a/modules/ecs-task-sftpgo/iam.tf
+++ b/modules/ecs-task-sftpgo/iam.tf
@@ -31,7 +31,9 @@ resource "aws_iam_role_policy_attachment" "attach_ecs_task_cloudwatch_logs_polic
 }
 
 resource "aws_iam_role_policy_attachment" "attach_additional_policy" {
-  for_each = toset(var.arn_attach_additional_policy)
+  for_each = {
+    for idx, arn in var.arn_attach_additional_policy : tostring(idx) => arn
+  }
 
   policy_arn = each.value
   role       = aws_iam_role.ecs_task_role.name

--- a/modules/ecs-task-sftpgo/main.tf
+++ b/modules/ecs-task-sftpgo/main.tf
@@ -22,15 +22,15 @@ locals {
   )
 
   normalized_port_mappings = [
-    for mapping in local.base_port_mappings : {
-      for key, value in {
-        containerPort = mapping.container_port
-        hostPort      = lookup(mapping, "host_port", mapping.container_port)
+    for mapping in local.base_port_mappings : merge(
+      {
+        containerPort = tonumber(mapping.container_port)
+        hostPort      = tonumber(lookup(mapping, "host_port", mapping.container_port))
         protocol      = lookup(mapping, "protocol", "tcp")
-        appProtocol   = lookup(mapping, "app_protocol", null)
-        name          = lookup(mapping, "name", null)
-      } : key => value if value != null
-    }
+      },
+      lookup(mapping, "app_protocol", null) != null ? { appProtocol = mapping.app_protocol } : {},
+      lookup(mapping, "name", null) != null ? { name = mapping.name } : {}
+    )
   ]
 
   volume_name = coalesce(var.volume_name, "sftpgo-efs-volume")


### PR DESCRIPTION
## Summary

- Fix ECS task definition error: `containerPort` must be int, not string in JSON
- Fix `for_each` error on `aws_iam_role_policy_attachment.attach_additional_policy` when policy ARN is unknown at plan time

## Test plan

- [ ] Re-run SFTPGo Terraform apply in staging
- [ ] Confirm `aws_ecs_task_definition` is created successfully


Made with [Cursor](https://cursor.com)