### PR TITLE
feat(vpc): optional NAT strategy and no-default-route private subnets

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,6 +1,20 @@
 locals {
   public_subnets  = { for k, v in var.subnets : k => v if v.public }
   private_subnets = { for k, v in var.subnets : k => v if v.public == false }
+
+  # NAT strategy:
+  # - "per_public_subnet" (default): one NAT per public subnet (current behavior,
+  #   keeps for_each keys and resource addresses unchanged for existing consumers)
+  # - "referenced_only": NAT only for public subnets referenced by some nat_key
+  referenced_nat_keys = distinct([
+    for k, v in local.private_subnets : v.nat_key if v.nat_key != ""
+  ])
+  nat_subnets = var.nat_strategy == "per_public_subnet" ? local.public_subnets : {
+    for k, v in local.public_subnets : k => v if contains(local.referenced_nat_keys, k)
+  }
+
+  # Private subnets with nat_key = "" get no default route (egress via VPC endpoints only)
+  private_subnets_with_nat = { for k, v in local.private_subnets : k => v if v.nat_key != "" }
 }
 
 resource "aws_vpc" "this" {
@@ -36,7 +50,7 @@ resource "aws_subnet" "this" {
 }
 
 resource "aws_eip" "nat" {
-  for_each = local.public_subnets
+  for_each = local.nat_subnets
 
   domain = "vpc"
 
@@ -46,7 +60,7 @@ resource "aws_eip" "nat" {
 }
 
 resource "aws_nat_gateway" "this" {
-  for_each = local.public_subnets
+  for_each = local.nat_subnets
 
   allocation_id = aws_eip.nat[each.key].id
   subnet_id     = aws_subnet.this[each.key].id
@@ -88,11 +102,11 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route" "private_internet" {
-  for_each = local.private_subnets
+  for_each = local.private_subnets_with_nat
 
   route_table_id         = aws_route_table.private[each.key].id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.this[local.private_subnets[each.key].nat_key].id
+  nat_gateway_id         = aws_nat_gateway.this[each.value.nat_key].id
 }
 
 resource "aws_route_table_association" "private" {

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -16,16 +16,14 @@ variable "subnets" {
     public  = bool
     nat_key = string
   }))
-  description = "Subnets definition map. For private subnets, nat_key must reference a public subnet key."
+  description = "Subnets definition map. For private subnets, nat_key must reference a public subnet key, or be \"\" for no default route (egress via VPC endpoints only)."
 
   validation {
     condition = length([
       for k, v in var.subnets : k
-      if v.public == false && (
-        v.nat_key == "" || !contains([for pk, pv in var.subnets : pk if pv.public], v.nat_key)
-      )
+      if v.public == false && v.nat_key != "" && !contains([for pk, pv in var.subnets : pk if pv.public], v.nat_key)
     ]) == 0
-    error_message = "Each private subnet must set nat_key to an existing public subnet key."
+    error_message = "Each private subnet must set nat_key to an existing public subnet key, or \"\" for no default route."
   }
 }
 
@@ -67,5 +65,16 @@ variable "db_subnet_group_name" {
   validation {
     condition     = var.create_db_subnet_group ? var.db_subnet_group_name != null && var.db_subnet_group_name != "" : true
     error_message = "db_subnet_group_name must be set when create_db_subnet_group is true."
+  }
+}
+
+variable "nat_strategy" {
+  type        = string
+  default     = "per_public_subnet"
+  description = "NAT Gateway creation strategy. \"per_public_subnet\" (default) creates one NAT per public subnet (current behavior). \"referenced_only\" creates NATs only for public subnets referenced by at least one private subnet's nat_key, avoiding idle NAT Gateways."
+
+  validation {
+    condition     = contains(["per_public_subnet", "referenced_only"], var.nat_strategy)
+    error_message = "nat_strategy must be \"per_public_subnet\" or \"referenced_only\"."
   }
 }


### PR DESCRIPTION
## Motivação

O módulo `vpc` cria hoje **1 NAT Gateway por subnet pública, incondicionalmente** (`aws_nat_gateway.this` com `for_each = local.public_subnets`), e a validação de `var.subnets` **obriga** toda subnet privada a referenciar um `nat_key`. Na prática, isso induz o padrão "1 NAT por AZ" mesmo quando o tráfego não justifica, e impede o desenho "subnet privada sem rota default" (egress somente via VPC endpoints), cada vez mais comum em arquiteturas serverless.

### Caso real — conta Escale Data - Prod (950509508909)

Durante a revisão de custos de ago/2026 encontramos exatamente esse padrão em produção: **4 NAT Gateways** (1 por AZ). Medição de 7 dias via CloudWatch:

| NAT Gateway | BytesOutToDestination (7d) | ActiveConnectionCount máx (7d) |
|---|---:|---:|
| nat-006890db6c5ac5ef2 | 103,8 GB | em uso |
| nat-090026cac9919b1c6 | **0** | **0** |
| nat-06e6ee383ae09aa1d | **0** | **0** |
| nat-028f7430427b8ee56 | **0** | **0** |

**100% do tráfego flui por um único NAT.** Os outros 3 custam ~US$ 32,85/mês cada em horas provisionadas (+ 3 EIPs): **~US$ 98/mês (~US$ 1.180/ano) sem função alguma.**

## O que muda

1. **Nova variável `nat_strategy`** (string, default `"per_public_subnet"`):
   - `per_public_subnet` (**default**) — comportamento idêntico ao atual;
   - `referenced_only` — cria NAT/EIP apenas para subnets públicas referenciadas pelo `nat_key` de ao menos uma subnet privada (elimina NATs ociosos por construção).
2. **`nat_key` aceita `""`** em subnets privadas — a subnet fica **sem rota default** (padrão para cargas que saem só por VPC endpoints). A `aws_route.private_internet` simplesmente não é criada para essas subnets.

## Compatibilidade retroativa (garantias)

- **Default preserva endereços de recurso e chaves de `for_each`**: com `nat_strategy = "per_public_subnet"` (default), `local.nat_subnets == local.public_subnets` — `terraform plan` é **no-op** para consumidores existentes. Nenhum NAT/EIP é destruído ou recriado (recriação de NAT = nova EIP = quebra de whitelists externas).
- **Sem mudança de tipo em `var.subnets`** — nada de `optional()`, sem exigência de versão nova de Terraform.
- Configurações existentes (todas com `nat_key` preenchido, por força da validação antiga) passam na validação nova sem alteração.
- `terraform fmt -check` e `terraform validate` OK.

## Exemplo de uso novo

```hcl
module "vpc" {
  source   = "git::https://github.com/escaletech/terraform-modules.git//modules/vpc?ref=<tag>"
  name     = "data-platform-dev"
  vpc_cidr = "10.100.0.0/16"

  nat_strategy = "referenced_only"

  subnets = {
    nat-a = { name = "nat-a", cidr = "10.100.0.0/24",  az = "us-east-1a", public = true,  nat_key = "" }
    eks-a = { name = "eks-a", cidr = "10.100.10.0/24", az = "us-east-1a", public = false, nat_key = "nat-a" }
    eks-b = { name = "eks-b", cidr = "10.100.11.0/24", az = "us-east-1b", public = false, nat_key = "nat-a" }
    dms-a = { name = "dms-a", cidr = "10.100.1.0/24",  az = "us-east-1a", public = false, nat_key = "" } # só endpoints
  }
}
```

## Pós-merge

Sugerimos **criar uma tag de release** (ex.: `v1.1.0`): a última tag do repo (`v1.0.0`) é de jan/2025 e **anterior à criação deste módulo** (#275, jan/2026) — hoje não há como pinar o `modules/vpc` por tag, o que força consumidores a apontar `master` ou SHA.

## Contexto

Mudança motivada pela criação da infra do projeto data-platform (contas novas dev/prd), que usará este módulo. Feliz em ajustar o que o time preferir — inclusive dividir em dois PRs (estratégia de NAT / `nat_key` vazio) se facilitar o review.
