### PR TITLE
fix(eks): AWS provider v6 compatibility; feat(vpc): route table outputs

### DIFF
--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -223,10 +223,11 @@ resource "aws_autoscaling_group_tag" "nodes_group_name" {
 ##############
 
 resource "aws_eks_addon" "kube_proxy" {
-  cluster_name      = aws_eks_cluster.cluster.name
-  addon_name        = "kube-proxy"
-  addon_version     = var.kube_proxy_version
-  resolve_conflicts = "OVERWRITE"
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "kube-proxy"
+  addon_version               = var.kube_proxy_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
   tags = merge(var.tags, {
     "eks_addon" = "kube-proxy"
     }
@@ -234,10 +235,11 @@ resource "aws_eks_addon" "kube_proxy" {
 }
 
 resource "aws_eks_addon" "core_dns" {
-  cluster_name      = aws_eks_cluster.cluster.name
-  addon_name        = "coredns"
-  addon_version     = var.core_dns_version
-  resolve_conflicts = "OVERWRITE"
+  cluster_name                = aws_eks_cluster.cluster.name
+  addon_name                  = "coredns"
+  addon_version               = var.core_dns_version
+  resolve_conflicts_on_create = "OVERWRITE"
+  resolve_conflicts_on_update = "OVERWRITE"
   tags = merge(var.tags, {
     "eks_addon" = "coredns"
     }

--- a/modules/eks/versions.tf
+++ b/modules/eks/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_providers {
+    # Floor introduced by resolve_conflicts_on_create/on_update (provider >= 5.0).
+    # Range open on purpose: consumers pin the effective version (v5 or v6).
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -25,3 +25,11 @@ output "nat_gateway_ids" {
 output "db_subnet_group_name" {
   value = var.create_db_subnet_group ? aws_db_subnet_group.this[0].name : null
 }
+
+output "public_route_table_id" {
+  value = aws_route_table.public.id
+}
+
+output "private_route_table_ids" {
+  value = { for k, v in aws_route_table.private : k => v.id }
+}


### PR DESCRIPTION
## Motivação

O módulo `eks` **não valida sob o provider AWS v6**: usa `resolve_conflicts` nos `aws_eks_addon` (kube-proxy e CoreDNS), argumento **removido no v6** (depreciado desde o v5). Qualquer consumidor com `aws ~> 6.x` recebe:

```
Error: Unsupported argument
  on modules/eks/main.tf line 229, in resource "aws_eks_addon" "kube_proxy":
 229:   resolve_conflicts = "OVERWRITE"
```

Encontrado ao consumir o módulo no projeto data-platform (contas novas, provider v6).

## Mudanças

**1. `eks`: compatibilidade com provider v6 (fix)**
`resolve_conflicts` → `resolve_conflicts_on_create` + `resolve_conflicts_on_update` (ambos `"OVERWRITE"`, preservando o comportamento). Os argumentos novos existem desde o provider **v5.0**, então o módulo passa a validar **em v5 e v6** — nenhum consumidor atual é afetado.

**2. `vpc`: outputs de route tables (aditivo)**
O módulo cria as route tables mas não as exporta — consumidores que precisam anexar **gateway VPC endpoints** (S3/DynamoDB) hoje recorrem a `data "aws_route_tables"` como workaround. Adiciona `public_route_table_id` e `private_route_table_ids` (map por chave de subnet). Mudança puramente aditiva.

## Validação

- `terraform validate` de `modules/eks` sob provider **v6**: falhava antes, **Success** depois
- `terraform validate` de `modules/vpc` sob provider v6: **Success**
- `terraform fmt` limpo

## Fora do escopo (registrado para follow-up, se fizer sentido)

Os **defaults** de `eks_version`/addons apontam para a era 1.21 (2021, fora de suporte). Não alterados aqui de propósito: mudar default pode impactar consumidor existente que dependa dele (upgrade de cluster é one-way). Sugestão futura: tornar as versões de addon `nullable` (omitir = AWS escolhe a compatível com o cluster).

Relacionado: #314 (vpc `nat_strategy`) — se ambos mergearem, uma tag de release (ex.: `v1.1.0`) cobriria os dois e permitiria consumo pinado por tag.
